### PR TITLE
Fix JSON-LD types of free_to_read and license_ref properties

### DIFF
--- a/niso-ali-1.0.json
+++ b/niso-ali-1.0.json
@@ -2,8 +2,6 @@
     "@context": {
 	"@vocab": "http://www.niso.org/schemas/ali/1.0/jsonld.json",
 	"xsd": "http://www.w3.org/2001/XMLSchema#",
-	"free_to_read": { "@type": "@id" },
-	"license_ref": { "@type": "@id" },
 	"uri": { "@type": "@id" },
 	"start_date": { "@type": "xsd:date" },
 	"end_date": { "@type": "xsd:date" }


### PR DESCRIPTION
A `@type` value of `@id` indicates that the value of this property is a string that represents a URI, which is not the case for either the free_to_read or license_ref properties.
