### PR TITLE
Start date must be optional

### DIFF
--- a/niso-ali-1.0.xsd
+++ b/niso-ali-1.0.xsd
@@ -4,7 +4,7 @@
   <xsd:element name="free_to_read">
     <xsd:complexType>
       <xsd:attribute name="end_date" use="optional" type="xsd:date"/>
-      <xsd:attribute name="start_date" use="required" type="xsd:date"/>
+      <xsd:attribute name="start_date" use="optional" type="xsd:date"/>
     </xsd:complexType>
   </xsd:element>
   <xsd:element name="license_ref">


### PR DESCRIPTION
In order for the schema to support an empty `<free_to_read/>` element, the `start_date` attribute must be optional.
